### PR TITLE
Fix command delays

### DIFF
--- a/src/CommandManager.ts
+++ b/src/CommandManager.ts
@@ -252,15 +252,6 @@ export class CommandManager<
     const filterContext = context[0];
 
     for (const command of this.commands) {
-      if (command.preFilters.length) {
-        let passed = false;
-        for (const filter of command.preFilters) {
-          passed = await filter(command, filterContext as TContext);
-          if (!passed) break;
-        }
-        if (!passed) continue;
-      }
-
       const matchedCommand = await this.tryMatchingCommand(command, str, filterContext as TContext);
       if (matchedCommand === null) continue;
 
@@ -268,6 +259,15 @@ export class CommandManager<
         lastError = matchedCommand.error;
         lastErrorCmd = command;
         continue;
+      }
+
+      if (command.preFilters.length) {
+        let passed = false;
+        for (const filter of command.preFilters) {
+          passed = await filter(command, filterContext as TContext);
+          if (!passed) break;
+        }
+        if (!passed) continue;
       }
 
       onlyErrors = false;


### PR DESCRIPTION
As used in https://github.com/Dragory/modmailbot, each command prefilter may check a channel ID against an entire database of threads. As a standalone operation, this has an unnoticeable effect, but when there are over forty commands and nearly one hundred thousand threads, a consistent delay is present on every Modmail command run in the inbox server.

Recently, we pinpointed the source of the delay to this module. Several months ago, the support server advised us to contact Discord for selectively limiting the bot's requests to one particular server. 

This change drastically improves the performance (1300ms to <1ms) of findMatchingCommand in large-scale workloads by putting the cheaper and more specific tryMatchingCommand check before the prefilters. 